### PR TITLE
fix wrong datatype image

### DIFF
--- a/init.py
+++ b/init.py
@@ -177,4 +177,7 @@ if __name__ == '__main__':
         cv.waitKey(0)
 
         if FLAGS.save_image_with_name is not None:
+            out = cv.normalize(out, None, alpha=0, beta=1, norm_type=cv.NORM_MINMAX, dtype=cv.CV_32F)
+            out *= 255
+            out = out.astype("uint8")
             cv.imwrite(FLAGS.save_image_with_name, out)


### PR DESCRIPTION
The image looks black because it was saved to the wrong data type. It was normalized to the range 0-1 and converted to uint8 0-255 range